### PR TITLE
Move trophy indicator to the top-right corner of player card

### DIFF
--- a/sources/HemSoft.EggIncTracker.Dashboard.BlazorServer/Components/PlayerCard.razor
+++ b/sources/HemSoft.EggIncTracker.Dashboard.BlazorServer/Components/PlayerCard.razor
@@ -291,6 +291,15 @@ else
 
 
 <style>
+    /* Trophy indicator */
+    .goals-achieved-indicator {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        z-index: 5;
+        animation: pulse 2s infinite;
+    }
+
     /* Fireworks container */
     .fireworks-container {
         position: absolute;


### PR DESCRIPTION
This PR addresses issue #3 by moving the trophy indicator (when achieved) from the center of the player card to the top-right corner to gain more visual space.