### PR TITLE
Rocket Mission Display Improvements

### DIFF
--- a/sources/HemSoft.EggIncTracker.Dashboard.BlazorServer/Components/Pages/RocketDashboard.razor.cs
+++ b/sources/HemSoft.EggIncTracker.Dashboard.BlazorServer/Components/Pages/RocketDashboard.razor.cs
@@ -28,7 +28,7 @@ public partial class RocketDashboard : IDisposable, IAsyncDisposable
     private string _timeSinceLastUpdate = "Never";
     private bool IsLoading = false;
     private Timer? _refreshTimer;
-    private const int RefreshIntervalMs = 30000; // 30 seconds
+    private const int RefreshIntervalMs = 1800000; // 30 minutes
 
     private DashboardPlayer _kingFridayPlayer = new();
     private DashboardPlayer _kingSaturdayPlayer = new();

--- a/sources/HemSoft.EggIncTracker.Dashboard.BlazorServer/Services/PlayerCardService.cs
+++ b/sources/HemSoft.EggIncTracker.Dashboard.BlazorServer/Services/PlayerCardService.cs
@@ -182,11 +182,11 @@ public class PlayerCardService
             _refreshTimer?.Dispose(); // Dispose existing timer if any
             _updateTimer?.Dispose();
 
-            _refreshTimer = new Timer(30000); // 30 seconds
+            _refreshTimer = new Timer(1800000); // 30 minutes
             _refreshTimer.Elapsed += OnRefreshTimerElapsed;
             _refreshTimer.AutoReset = true;
             _refreshTimer.Start();
-            _logger.LogInformation("Main refresh timer started (30 second interval)");
+            _logger.LogInformation("Main refresh timer started (30 minute interval)");
 
             _updateTimer = new Timer(1000); // 1 second
             _updateTimer.Elapsed += OnUpdateTimerElapsed;

--- a/sources/HemSoft.EggIncTracker.Dashboard.BlazorServer/Services/RocketMissionService.cs
+++ b/sources/HemSoft.EggIncTracker.Dashboard.BlazorServer/Services/RocketMissionService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using HemSoft.EggIncTracker.Dashboard.BlazorServer.Utilities;
 using HemSoft.EggIncTracker.Data.Dtos;
 using HemSoft.EggIncTracker.Domain;
 using Microsoft.Extensions.Logging;
@@ -36,7 +37,7 @@ public class RocketMissionService
     {
         { 0, "Unknown" },
         { 1, "Fueling" },
-        { 2, "Traveling" },
+        { 2, "Exploring" },
         { 3, "Returned" },
         { 4, "Complete" },
         { 5, "Archived" }
@@ -221,11 +222,11 @@ public class RocketMissionService
         }
         else if (timeSpan.TotalHours >= 1)
         {
-            return $"{timeSpan.Hours}h {timeSpan.Minutes}m";
+            return $"{timeSpan.Hours}h {timeSpan.Minutes}m {timeSpan.Seconds}s";
         }
         else
         {
-            return $"{timeSpan.Minutes}m {timeSpan.Seconds}s";
+            return $"{timeSpan.Minutes:D2}:{timeSpan.Seconds:D2}";
         }
     }
 
@@ -261,7 +262,7 @@ public class RocketMissionService
     /// <returns>Ship name</returns>
     public string GetShipName(int shipType)
     {
-        return ShipTypes.TryGetValue(shipType, out string? name) ? name : $"Unknown Ship ({shipType})";
+        return ShipNameMapper.GetShipName(shipType);
     }
 
     /// <summary>
@@ -271,7 +272,7 @@ public class RocketMissionService
     /// <returns>Status name</returns>
     public string GetStatusName(int statusCode)
     {
-        return MissionStatuses.TryGetValue(statusCode, out string? name) ? name : $"Unknown Status ({statusCode})";
+        return ShipNameMapper.GetStatusDescription(statusCode);
     }
 
     /// <summary>

--- a/sources/HemSoft.EggIncTracker.Dashboard.BlazorServer/Utilities/ShipNameMapper.cs
+++ b/sources/HemSoft.EggIncTracker.Dashboard.BlazorServer/Utilities/ShipNameMapper.cs
@@ -1,0 +1,55 @@
+namespace HemSoft.EggIncTracker.Dashboard.BlazorServer.Utilities;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// Utility class to map ship IDs to their names
+/// </summary>
+public static class ShipNameMapper
+{
+    private static readonly Dictionary<int, string> ShipNames = new()
+    {
+        { 0, "Chicken One" },
+        { 1, "Chicken Heavy" },
+        { 2, "BCR" },
+        { 3, "Quintillion Chicken" },
+        { 4, "Corellihen Corvette" },
+        { 5, "Galeggtica" },
+        { 6, "Chickfiant" },
+        { 7, "Voyegger" },
+        { 8, "Henerprise" },
+        { 9, "Defihent" },
+        { 10, "Cornish-Ex Hen" }
+    };
+
+    /// <summary>
+    /// Get the name of a ship by its ID
+    /// </summary>
+    /// <param name="shipId">The ship ID</param>
+    /// <returns>The ship name, or "Unknown Ship" if the ID is not found</returns>
+    public static string GetShipName(int shipId)
+    {
+        return ShipNames.TryGetValue(shipId, out var name) ? name : $"Unknown Ship ({shipId})";
+    }
+
+    /// <summary>
+    /// Get the status description for a mission status code
+    /// </summary>
+    /// <param name="statusCode">The status code</param>
+    /// <returns>The status description</returns>
+    public static string GetStatusDescription(int statusCode)
+    {
+        return statusCode switch
+        {
+            0 => "Unknown",
+            1 => "Fueling",
+            2 => "In Progress",
+            3 => "Returned",
+            4 => "Complete",
+            5 => "Archived",
+            10 => "In Progress",
+            25 => "Archived",
+            _ => $"Unknown ({statusCode})"
+        };
+    }
+}


### PR DESCRIPTION
## Changes Made

- Centered the time remaining text for better emphasis
- Added a highly visible progress bar with a green border
- Fixed the status labels to correctly show "In Progress" instead of "Complete" for missions that are still in progress
- Updated the status colors to match the actual state (orange for in-progress)
- Ensured the progress bar is always visible with a minimum value of 5%
- Removed unnecessary UI elements to reduce clutter
- Applied consistent styling across all mission types
- Changed refresh interval from 30 seconds to 30 minutes to reduce load
- Added a ShipNameMapper utility class for better ship name and status handling
- Improved time formatting for better readability

These changes make the rocket mission status information much clearer and more intuitive for users. The centered time remaining with the progress bar directly below it provides a clean, easy-to-understand visual representation of mission progress.

Closes #6
