### PR TITLE
Fix SE Gained and SE This Week values not displaying on Maj Player Updates page

### DIFF
--- a/sources/HemSoft.EggIncTracker.Dashboard.BlazorServer/Components/Pages/MajPlayerUpdates.razor
+++ b/sources/HemSoft.EggIncTracker.Dashboard.BlazorServer/Components/Pages/MajPlayerUpdates.razor
@@ -33,7 +33,7 @@
             {
                 <MudTable Items="@playerUpdates" Dense="true" Hover="true" Breakpoint="Breakpoint.Sm" Loading="@isLoading"
                     LoadingProgressColor="Color.Primary" T="MajPlayerRankingDto" HeaderClass="table-header"
-                    Filter="FilterFunc" RowsPerPage="100">
+                    Filter="FilterFunc" RowsPerPage="100" SortBy="x => x.Updated" SortDirection="SortDirection.Descending">
                     <HeaderContent>
                         <MudTh
                             Style="font-weight: bold; background-color: var(--mud-palette-primary); color: var(--mud-palette-primary-text);">

--- a/sources/HemSoft.EggIncTracker.Dashboard.BlazorServer/Components/Pages/MajPlayerUpdates.razor.cs
+++ b/sources/HemSoft.EggIncTracker.Dashboard.BlazorServer/Components/Pages/MajPlayerUpdates.razor.cs
@@ -151,6 +151,7 @@ public partial class MajPlayerUpdates : IDisposable
                 var latestByPlayer = rankings
                     .GroupBy(r => r.IGN)
                     .Select(g => g.OrderByDescending(r => r.Updated).First())
+                    .OrderByDescending(r => r.Updated) // Sort by newest first
                     .ToList();
 
                 playerUpdates = latestByPlayer;

--- a/sources/HemSoft.EggIncTracker.Domain/MajPlayerRankingManager.cs
+++ b/sources/HemSoft.EggIncTracker.Domain/MajPlayerRankingManager.cs
@@ -514,7 +514,7 @@ public static class MajPlayerRankingManager
             // Get the most recent date (within the last 3 weeks)
             var threeWeeksAgo = DateTime.UtcNow.AddDays(-21);
 
-            // Get all rankings from the last 3 weeks, grouped by player name
+            // Get all rankings from the last 3 weeks
             var rankings = await context.MajPlayerRankings
                 .Where(r => r.Updated >= threeWeeksAgo)
                 .OrderByDescending(r => r.Updated)
@@ -529,6 +529,59 @@ public static class MajPlayerRankingManager
 
             logger?.LogInformation("Found {Count} latest major player rankings in database", latestRankings.Count);
 
+            // Calculate SEGains for each player
+            var playerGroups = rankings
+                .GroupBy(r => r.IGN)
+                .ToDictionary(g => g.Key, g => g.OrderByDescending(r => r.Updated).ToList());
+
+            foreach (var ranking in latestRankings)
+            {
+                if (playerGroups.TryGetValue(ranking.IGN, out var playerRecords) && playerRecords.Count > 1)
+                {
+                    // Get the current and previous records
+                    var currentRecord = playerRecords[0];
+                    var previousRecord = playerRecords[1];
+
+                    // Calculate the gain
+                    var gain = currentRecord.SENumber - previousRecord.SENumber;
+
+                    if (gain > 0)
+                    {
+                        // For scientific notation
+                        if (currentRecord.SEString.EndsWith('s') && previousRecord.SEString.EndsWith('s'))
+                        {
+                            var currentValue = decimal.Parse(currentRecord.SEString.TrimEnd('s'));
+                            var previousValue = decimal.Parse(previousRecord.SEString.TrimEnd('s'));
+                            var diff = currentValue - previousValue;
+
+                            if (diff > 0)
+                            {
+                                ranking.SEGains = $"{diff:0.00}s";
+                            }
+                            else
+                            {
+                                ranking.SEGains = "0";
+                            }
+                        }
+                        else
+                        {
+                            ranking.SEGains = FormatSEGain(gain);
+                        }
+                    }
+                    else
+                    {
+                        ranking.SEGains = "0";
+                    }
+                }
+                else
+                {
+                    ranking.SEGains = "N/A";
+                }
+            }
+
+            // Calculate weekly gains
+            await CalculateWeeklyGains(latestRankings, context, logger);
+
             // Apply the limit if specified
             return limitTo > 0 && latestRankings.Count > limitTo
                 ? [.. latestRankings.Take(limitTo)]
@@ -540,6 +593,173 @@ public static class MajPlayerRankingManager
 
             // Return an empty list in case of error
             return [];
+        }
+    }
+
+    /// <summary>
+    /// Format a Soul Egg gain value
+    /// </summary>
+    private static string FormatSEGain(decimal gain)
+    {
+        if (gain >= 1_000_000_000_000_000_000) // Quintillion
+        {
+            return $"{gain / 1_000_000_000_000_000_000:0.00}Q";
+        }
+        else if (gain >= 1_000_000_000_000_000) // Quadrillion
+        {
+            return $"{gain / 1_000_000_000_000_000:0.00}q";
+        }
+        else if (gain >= 1_000_000_000_000) // Trillion
+        {
+            return $"{gain / 1_000_000_000_000:0.00}T";
+        }
+        else if (gain >= 1_000_000_000) // Billion
+        {
+            return $"{gain / 1_000_000_000:0.00}B";
+        }
+        else if (gain >= 1_000_000) // Million
+        {
+            return $"{gain / 1_000_000:0.00}M";
+        }
+        else if (gain >= 1_000) // Thousand
+        {
+            return $"{gain / 1_000:0.00}K";
+        }
+        else
+        {
+            return gain.ToString("0.00");
+        }
+    }
+
+    /// <summary>
+    /// Calculate weekly gains for all players
+    /// </summary>
+    private static async Task CalculateWeeklyGains(List<MajPlayerRankingDto> rankings, EggIncContext context, ILogger? logger)
+    {
+        try
+        {
+            // Get the start of the week (Monday)
+            var today = DateTime.Today;
+            // Calculate Monday of the current week
+            // In C#, DayOfWeek.Sunday = 0, DayOfWeek.Monday = 1, etc.
+            // So for Monday, we need to subtract (DayOfWeek - 1) or 0 if it's Sunday
+            int daysToSubtract = today.DayOfWeek == DayOfWeek.Sunday ? 6 : (int)today.DayOfWeek - 1;
+            var weekStartDate = today.AddDays(-daysToSubtract);
+            logger?.LogInformation($"Calculating weekly gains from {weekStartDate} to {today}");
+
+            // Create a dictionary to store the weekly gains for each player
+            var weeklyGainsByPlayer = new Dictionary<string, string>();
+
+            // Get unique player names from the rankings
+            var uniquePlayerNames = rankings.Select(r => r.IGN).Distinct().ToList();
+            logger?.LogInformation($"Processing weekly gains for {uniquePlayerNames.Count} unique players");
+
+            // Get all records for all players in a single query to reduce database calls
+            var allPlayerRecords = await context.MajPlayerRankings
+                .Where(r => uniquePlayerNames.Contains(r.IGN) && r.Updated >= weekStartDate.AddDays(-7))
+                .OrderBy(r => r.IGN)
+                .ThenBy(r => r.Updated)
+                .ToListAsync();
+
+            logger?.LogInformation($"Retrieved {allPlayerRecords.Count} total records for all players");
+
+            // Group records by player name
+            var recordsByPlayer = allPlayerRecords.GroupBy(r => r.IGN).ToDictionary(g => g.Key, g => g.ToList());
+
+            // Process each player
+            foreach (var playerName in uniquePlayerNames)
+            {
+                try
+                {
+                    // Skip processing if we don't have records for this player
+                    if (!recordsByPlayer.TryGetValue(playerName, out var playerRecords) || !playerRecords.Any())
+                    {
+                        weeklyGainsByPlayer[playerName] = "N/A";
+                        continue;
+                    }
+
+                    // Find the record closest to but before the week start
+                    var recordsBeforeWeek = playerRecords.Where(r => r.Updated < weekStartDate).ToList();
+                    var recordsThisWeek = playerRecords.Where(r => r.Updated >= weekStartDate).ToList();
+
+                    // Get the baseline record (record just before week start or earliest record of the week)
+                    var baselineRecord = recordsBeforeWeek.Count > 0
+                        ? recordsBeforeWeek.OrderByDescending(r => r.Updated).First()
+                        : (recordsThisWeek.Count > 0 ? recordsThisWeek.OrderBy(r => r.Updated).First() : null);
+
+                    // Get the latest record
+                    var latestRecord = playerRecords.OrderByDescending(r => r.Updated).First();
+
+                    if (baselineRecord != null)
+                    {
+                        // Calculate the weekly gain
+                        if (latestRecord.SEString.EndsWith('s') && baselineRecord.SEString.EndsWith('s'))
+                        {
+                            // Scientific notation
+                            var latestValue = decimal.Parse(latestRecord.SEString.TrimEnd('s'));
+                            var baselineValue = decimal.Parse(baselineRecord.SEString.TrimEnd('s'));
+                            var diff = latestValue - baselineValue;
+
+                            if (diff > 0)
+                            {
+                                weeklyGainsByPlayer[playerName] = $"{diff:0.00}s";
+                            }
+                            else
+                            {
+                                weeklyGainsByPlayer[playerName] = "0";
+                            }
+                        }
+                        else
+                        {
+                            // Regular notation
+                            var weeklyGain = latestRecord.SENumber - baselineRecord.SENumber;
+
+                            if (weeklyGain > 0)
+                            {
+                                weeklyGainsByPlayer[playerName] = FormatSEGain(weeklyGain);
+                            }
+                            else
+                            {
+                                weeklyGainsByPlayer[playerName] = "0";
+                            }
+                        }
+                    }
+                    else
+                    {
+                        weeklyGainsByPlayer[playerName] = "N/A";
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogError(ex, $"Error calculating weekly gains for player {playerName}");
+                    weeklyGainsByPlayer[playerName] = "Error";
+                }
+            }
+
+            // Now update the SEGainsWeek property for each record in the rankings list
+            foreach (var record in rankings)
+            {
+                if (weeklyGainsByPlayer.TryGetValue(record.IGN, out var weeklyGain))
+                {
+                    record.SEGainsWeek = weeklyGain;
+                }
+                else
+                {
+                    record.SEGainsWeek = "N/A";
+                }
+            }
+
+            // Log a summary of the results
+            logger?.LogInformation($"Weekly gains calculated for {weeklyGainsByPlayer.Count} players");
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex, "Error calculating weekly gains");
+            // Set all weekly gains to N/A in case of error
+            foreach (var record in rankings)
+            {
+                record.SEGainsWeek = "N/A";
+            }
         }
     }
 

--- a/sources/HemSoft.EggIncTracker.Domain/MajPlayerRankingManager.cs
+++ b/sources/HemSoft.EggIncTracker.Domain/MajPlayerRankingManager.cs
@@ -524,7 +524,7 @@ public static class MajPlayerRankingManager
             var latestRankings = rankings
                 .GroupBy(r => r.IGN)
                 .Select(g => g.OrderByDescending(r => r.Updated).First())
-                .OrderBy(r => r.Ranking)
+                .OrderByDescending(r => r.Updated) // Sort by newest first
                 .ToList();
 
             logger?.LogInformation("Found {Count} latest major player rankings in database", latestRankings.Count);


### PR DESCRIPTION
Fixes #19\n\n## Changes\n\n- Modified the GetLatestMajPlayerRankingsAsync method in MajPlayerRankingManager to calculate the SEGains and SEGainsWeek values\n- Added a FormatSEGain method to format the SE gain values with appropriate notation\n- Added a CalculateWeeklyGains method to calculate the weekly SE gains for each player\n- Updated the sorting in both the manager and the UI to display player updates by newest first\n\n## Testing\n\nAfter these changes, the SE Gained and SE This Week columns on the Maj Player Updates page should display the calculated values instead of 'N/A', and the list should be sorted by newest first.